### PR TITLE
leongross/serial-sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,7 @@ dependencies = [
  "critical-section",
  "defmt",
  "embassy-sync",
+ "embedded-io",
  "embedded-io-adapters",
  "embedded-io-async",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ defmt = "0.3"
 deku = { git = "https://github.com/CodeConstruct/deku.git", tag = "cc/deku-v0.19.1/no-alloc-3", default-features = false }
 embedded-io-adapters = { version = "0.6", features = ["std", "futures-03"] }
 embedded-io-async = "0.6"
+embedded-io = "0.6"
 enumset = "1.1"
 env_logger = "0.11.3"
 heapless = "0.8"

--- a/ci/runtests.sh
+++ b/ci/runtests.sh
@@ -53,6 +53,25 @@ cargo build --target thumbv7em-none-eabihf --features defmt --no-default-feature
 cargo build --features log
 )
 
-cargo doc
+FEATURES_ASYNC="embassy"
+FEATURES_SYNC=""
+
+declare -a FEATURES=(
+    "$FEATURES_SYNC"
+    "$FEATURES_ASYNC"
+)
+
+# mctp-estack, sync an async
+(
+cd mctp-estack
+for feature in "${FEATURES[@]}"; do
+    cargo test --features="$feature"
+done;
+)
+
+# run cargo doc tests
+for feature in "${FEATURES[@]}"; do
+    cargo doc --features="$feature"
+done;
 
 echo success

--- a/ci/runtests.sh
+++ b/ci/runtests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -v
 set -e
@@ -15,7 +15,7 @@ cargo fmt -- --check
 
 # Check everything first
 cargo check --all-targets --locked
-if [ -z "NO_CLIPPY" ]; then
+if [ -z "$NO_CLIPPY" ]; then
     cargo clippy --all-targets
 fi
 
@@ -27,14 +27,14 @@ cargo test
 NOSTD_CRATES="mctp pldm pldm-fw pldm-platform pldm-file"
 for c in $NOSTD_CRATES; do
     (
-    cd $c
+    cd "$c"
     cargo build --target thumbv7em-none-eabihf --no-default-features
     )
 done
 ALLOC_CRATES="pldm pldm-platform pldm-file"
 for c in $ALLOC_CRATES; do
     (
-    cd $c
+    cd "$c"
     cargo build --target thumbv7em-none-eabihf --no-default-features --features alloc
     )
 done

--- a/mctp-estack/Cargo.toml
+++ b/mctp-estack/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.85"
 [dependencies]
 crc = { workspace = true }
 defmt = { workspace = true, optional = true }
-embassy-sync = "0.7"
+embassy-sync = { version = "0.7", optional = true }
 embedded-io-async = { workspace = true }
 heapless = { workspace = true }
 log = { workspace = true, optional = true }
@@ -33,3 +33,4 @@ default = ["log"]
 std = ["mctp/std"]
 log = ["dep:log"]
 defmt = ["mctp/defmt", "dep:defmt" ]
+embassy = ["dep:embassy-sync"]

--- a/mctp-estack/Cargo.toml
+++ b/mctp-estack/Cargo.toml
@@ -12,6 +12,7 @@ rust-version = "1.85"
 crc = { workspace = true }
 defmt = { workspace = true, optional = true }
 embassy-sync = { version = "0.7", optional = true }
+embedded-io.workspace = true
 embedded-io-async = { workspace = true, optional = true }
 heapless = { workspace = true }
 log = { workspace = true, optional = true }

--- a/mctp-estack/Cargo.toml
+++ b/mctp-estack/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.85"
 crc = { workspace = true }
 defmt = { workspace = true, optional = true }
 embassy-sync = { version = "0.7", optional = true }
-embedded-io-async = { workspace = true }
+embedded-io-async = { workspace = true, optional = true }
 heapless = { workspace = true }
 log = { workspace = true, optional = true }
 mctp = { workspace = true }
@@ -33,4 +33,5 @@ default = ["log"]
 std = ["mctp/std"]
 log = ["dep:log"]
 defmt = ["mctp/defmt", "dep:defmt" ]
-embassy = ["dep:embassy-sync"]
+embassy = ["dep:embassy-sync", "async"]
+async = ["dep:embedded-io-async"]

--- a/mctp-estack/README.md
+++ b/mctp-estack/README.md
@@ -3,6 +3,8 @@
 [API docs](https://docs.rs/mctp-estack)
 
 This is a MCTP stack suitable for embedded devices.
+A `async` Router for embassy based applications is available
+through the `embassy` feature.
 
 A `Router` instance handles feeding MCTP packets to and from user
 provided MCTP transports, and handles sending receiving MCTP messages
@@ -16,3 +18,7 @@ MCTP bridging between ports is supported by the `Router`.
 The core `Stack` handles IO-less MCTP message reassembly and fragmentation,
 and MCTP tag tracking. MCTP transport binding packet encoding and decoding is
 provided for I2C, USB, and serial.
+
+## Features
+- `embassy`: async `Router` for [Embassy](https://embassy.dev/)
+- `async`: [embedded-io-async](https://docs.rs/embedded-io-async/0.6.1/embedded_io_async/) serial transport binding (enabled by `embassy` feature)

--- a/mctp-estack/src/control.rs
+++ b/mctp-estack/src/control.rs
@@ -9,7 +9,9 @@
 use crate::fmt::*;
 #[cfg(feature = "embassy")]
 use crate::Router;
-use mctp::{AsyncRespChannel, Eid, Error, Listener, MsgIC, MsgType};
+#[cfg(feature = "embassy")]
+use mctp::{AsyncRespChannel, MsgIC};
+use mctp::{Eid, Error, Listener, MsgType};
 use uuid::Uuid;
 
 /// A `Result` with a MCTP control completion code as error.
@@ -192,7 +194,9 @@ pub struct MctpControlMsg<'a> {
     work: [u8; 2],
 }
 
+#[cfg(feature = "embassy")]
 const MAX_MSG_SIZE: usize = 20; /* largest is Get Endpoint UUID */
+#[cfg(feature = "embassy")]
 const MAX_MSG_TYPES: usize = 8;
 
 impl<'a> MctpControlMsg<'a> {

--- a/mctp-estack/src/control.rs
+++ b/mctp-estack/src/control.rs
@@ -7,6 +7,7 @@
 //! MCTP Control Protocol implementation
 
 use crate::fmt::*;
+#[cfg(feature = "embassy")]
 use crate::Router;
 use mctp::{AsyncRespChannel, Eid, Error, Listener, MsgIC, MsgType};
 use uuid::Uuid;
@@ -424,6 +425,7 @@ where
 }
 
 /// A Control Message handler.
+#[cfg(feature = "embassy")]
 pub struct MctpControl<'g, 'r> {
     rsp_buf: [u8; MAX_MSG_SIZE],
     types: heapless::Vec<MsgType, MAX_MSG_TYPES>,
@@ -431,6 +433,7 @@ pub struct MctpControl<'g, 'r> {
     router: &'g Router<'r>,
 }
 
+#[cfg(feature = "embassy")]
 impl<'g, 'r> MctpControl<'g, 'r> {
     /// Create a new instance.
     pub fn new(router: &'g Router<'r>) -> Self {

--- a/mctp-estack/src/lib.rs
+++ b/mctp-estack/src/lib.rs
@@ -60,6 +60,7 @@ pub mod control;
 pub mod fragment;
 pub mod i2c;
 mod reassemble;
+#[cfg(feature = "embassy")]
 pub mod router;
 pub mod serial;
 pub mod usb;
@@ -67,12 +68,14 @@ pub mod usb;
 mod util;
 mod proto;
 
+#[cfg(feature = "embassy")]
 #[rustfmt::skip]
 #[allow(clippy::needless_lifetimes)]
 mod zerocopy_channel;
 
 use fragment::{Fragmenter, SendOutput};
 use reassemble::Reassembler;
+#[cfg(feature = "embassy")]
 pub use router::Router;
 
 use crate::fmt::*;

--- a/mctp-estack/src/lib.rs
+++ b/mctp-estack/src/lib.rs
@@ -68,7 +68,6 @@ pub mod i2c;
 mod reassemble;
 #[cfg(feature = "embassy")]
 pub mod router;
-#[cfg(feature = "async")]
 pub mod serial;
 pub mod usb;
 #[macro_use]

--- a/mctp-estack/src/lib.rs
+++ b/mctp-estack/src/lib.rs
@@ -73,7 +73,7 @@ pub mod serial;
 pub mod usb;
 #[macro_use]
 mod util;
-mod proto;
+pub mod proto;
 
 #[cfg(feature = "embassy")]
 #[rustfmt::skip]

--- a/mctp-estack/src/lib.rs
+++ b/mctp-estack/src/lib.rs
@@ -72,7 +72,7 @@ pub mod serial;
 pub mod usb;
 #[macro_use]
 mod util;
-pub mod proto;
+mod proto;
 
 #[cfg(feature = "embassy")]
 #[rustfmt::skip]

--- a/mctp-estack/src/lib.rs
+++ b/mctp-estack/src/lib.rs
@@ -7,6 +7,8 @@
 //!
 //! This crate provides a MCTP stack that can be embedded in other programs
 //! or devices.
+//! A `async` Router for embassy based applications is available
+//! through the `embassy` feature.
 //!
 //! A [`Router`] object lets programs use a [`Stack`] with
 //! MCTP transport binding links. Each *Port* handles transmitting and receiving
@@ -19,6 +21,10 @@
 //!
 //! The IO-less [`Stack`] handles MCTP message formatting and parsing, independent
 //! of any particular MCTP transport binding.
+//!
+//! ## Features
+//! - `embassy`: async `Router` for [Embassy](https://embassy.dev/)
+//! - `async`: [embedded-io-async](https://docs.rs/embedded-io-async/0.6.1/embedded_io_async/) serial transport binding (enabled by `embassy` feature)
 //!
 //! ## Configuration
 //!
@@ -62,6 +68,7 @@ pub mod i2c;
 mod reassemble;
 #[cfg(feature = "embassy")]
 pub mod router;
+#[cfg(feature = "async")]
 pub mod serial;
 pub mod usb;
 #[macro_use]

--- a/mctp-estack/src/serial.rs
+++ b/mctp-estack/src/serial.rs
@@ -12,7 +12,11 @@ use mctp::{Error, Result};
 use crc::Crc;
 use heapless::Vec;
 
+#[cfg(feature = "embassy")]
 use embedded_io_async::{Read, Write};
+
+#[cfg(not(feature = "embassy"))]
+use embedded_io::{Read, Write};
 
 const MCTP_SERIAL_REVISION: u8 = 0x01;
 
@@ -68,6 +72,7 @@ impl MctpSerialHandler {
     /// Read a frame.
     ///
     /// This is async cancel-safe.
+    #[cfg(feature = "embassy")]
     pub async fn recv_async(&mut self, input: &mut impl Read) -> Result<&[u8]> {
         // TODO: This reads one byte a time, might need a buffering wrapper
         // for performance. Will require more thought about cancel-safety
@@ -96,9 +101,41 @@ impl MctpSerialHandler {
         }
     }
 
+    /// Read a frame synchronously.
+    /// This function blocks until at least one byte is available
+    #[cfg(not(feature = "embassy"))]
+    pub fn recv(&mut self, input: &mut impl Read) -> Result<&[u8]> {
+        // TODO: This reads one byte a time, might need a buffering wrapper
+        // for performance. Will require more thought about cancel-safety
+
+        loop {
+            let mut b = 0u8;
+            match input.read(core::slice::from_mut(&mut b)) {
+                Ok(1) => (),
+                Ok(0) => {
+                    trace!("Serial EOF");
+                    return Err(Error::RxFailure);
+                }
+                Ok(2..) => unreachable!(),
+                Err(_e) => {
+                    trace!("Serial read error");
+                    return Err(Error::RxFailure);
+                }
+            }
+
+            if let Some(_p) = self.feed_frame(b) {
+                return Ok(&self.rxbuf[2..][..self.rxcount]);
+            }
+        }
+    }
+
+    /// Feed a byte into the frame parser state machine.
+    /// Returns Some(&[u8]) when a complete frame is available, containing the MCTP packet.
+    /// Returns None if the frame is incomplete.
     fn feed_frame(&mut self, b: u8) -> Option<&[u8]> {
         trace!("serial read {:02x}", b);
 
+        // State machine from DSP0253 Figure 1
         match self.rxpos {
             Pos::FrameSearch => {
                 if b == FRAMING_FLAG {
@@ -181,6 +218,8 @@ impl MctpSerialHandler {
         None
     }
 
+    /// Asynchronously send a MCTP packet over serial provided by `output`.
+    #[cfg(feature = "embassy")]
     pub async fn send_async(
         &mut self,
         pkt: &[u8],
@@ -191,6 +230,18 @@ impl MctpSerialHandler {
             .map_err(|_e| Error::TxFailure)
     }
 
+    /// Synchronously send a MCTP packet over serial provided by `output`.
+    #[cfg(not(feature = "embassy"))]
+    pub fn send_sync(
+        &mut self,
+        pkt: &[u8],
+        output: &mut impl Write,
+    ) -> Result<()> {
+        Self::frame_to_serial(pkt, output).map_err(|_e| Error::TxFailure)
+    }
+
+    /// Frame a MCTP packet into a serial frame, writing to `output`.
+    #[cfg(feature = "embassy")]
     async fn frame_to_serial<W>(
         p: &[u8],
         output: &mut W,
@@ -214,6 +265,33 @@ impl MctpSerialHandler {
         Ok(())
     }
 
+    /// Frame a MCTP packet into a serial frame, writing to `output`.
+    #[cfg(not(feature = "embassy"))]
+    fn frame_to_serial<W>(
+        p: &[u8],
+        output: &mut W,
+    ) -> core::result::Result<(), W::Error>
+    where
+        W: Write,
+    {
+        debug_assert!(p.len() <= u8::MAX.into());
+        debug_assert!(p.len() > 4);
+
+        let start = [FRAMING_FLAG, MCTP_SERIAL_REVISION, p.len() as u8];
+        let mut cs = CRC_FCS.digest();
+        cs.update(&start[1..]);
+        cs.update(p);
+        let cs = !cs.finalize();
+
+        output.write_all(&start)?;
+        Self::write_escaped(p, output)?;
+        output.write_all(&cs.to_be_bytes())?;
+        output.write_all(&[FRAMING_FLAG])?;
+        Ok(())
+    }
+
+    /// Asynchronously write a byte slice to `output`, escaping 0x7e and 0x7d bytes.
+    #[cfg(feature = "embassy")]
     async fn write_escaped<W>(
         p: &[u8],
         output: &mut W,
@@ -239,6 +317,34 @@ impl MctpSerialHandler {
         }
         Ok(())
     }
+
+    /// Synchronously write a byte slice to `output`, escaping 0x7e and 0x7d bytes.
+    #[cfg(not(feature = "embassy"))]
+    fn write_escaped<W>(
+        p: &[u8],
+        output: &mut W,
+    ) -> core::result::Result<(), W::Error>
+    where
+        W: Write,
+    {
+        for c in
+            p.split_inclusive(|&b| b == FRAMING_FLAG || b == FRAMING_ESCAPE)
+        {
+            let (last, rest) = c.split_last().unwrap();
+            match *last {
+                FRAMING_FLAG => {
+                    output.write_all(rest)?;
+                    output.write_all(&[FRAMING_ESCAPE, FLAG_ESCAPED])?;
+                }
+                FRAMING_ESCAPE => {
+                    output.write_all(rest)?;
+                    output.write_all(&[FRAMING_ESCAPE, ESCAPE_ESCAPED])?;
+                }
+                _ => output.write_all(c)?,
+            }
+        }
+        Ok(())
+    }
 }
 
 impl Default for MctpSerialHandler {
@@ -251,8 +357,10 @@ impl Default for MctpSerialHandler {
 mod tests {
     use crate::serial::*;
     use crate::*;
-    use embedded_io_adapters::futures_03::FromFutures;
     use proptest::prelude::*;
+
+    #[cfg(feature = "embassy")]
+    use embedded_io_adapters::futures_03::FromFutures;
 
     fn start_log() {
         let _ = env_logger::Builder::new()
@@ -261,7 +369,8 @@ mod tests {
             .try_init();
     }
 
-    async fn do_roundtrip(payload: &[u8]) {
+    #[cfg(feature = "embassy")]
+    async fn do_roundtrip_async(payload: &[u8]) {
         let mut esc = vec![];
         let mut s = FromFutures::new(&mut esc);
         MctpSerialHandler::frame_to_serial(payload, &mut s)
@@ -276,26 +385,57 @@ mod tests {
         debug_assert_eq!(payload, packet);
     }
 
+    #[cfg(not(feature = "embassy"))]
+    fn do_roundtrip_sync(payload: &[u8]) {
+        let mut esc = vec![];
+        MctpSerialHandler::frame_to_serial(payload, &mut esc).unwrap();
+        debug!("{:02x?}", payload);
+        debug!("{:02x?}", esc);
+
+        let mut h = MctpSerialHandler::new();
+        let mut s = esc.as_slice();
+        let packet = h.recv(&mut s).unwrap();
+        debug_assert_eq!(payload, packet);
+    }
+
+    #[cfg(feature = "embassy")]
     #[test]
-    fn roundtrip_cases() {
+    fn roundtrip_cases_async() {
         // Fixed testcases
         start_log();
         smol::block_on(async {
             for payload in
                 [&[0x01, 0x5d, 0x0d, 0xf4, 0x01, 0x93, 0x7d, 0xcd, 0x36]]
             {
-                do_roundtrip(payload).await
+                do_roundtrip_async(payload).await
             }
         })
     }
 
+    #[cfg(not(feature = "embassy"))]
+    #[test]
+    fn roundtrip_cases_sync() {
+        let test_payload =
+            [&[0x01, 0x5d, 0x0d, 0xf4, 0x01, 0x93, 0x7d, 0xcd, 0x36]];
+        start_log();
+        for payload in test_payload {
+            do_roundtrip_sync(payload)
+        }
+    }
+
     proptest! {
+        #[cfg(feature = "embassy")]
         #[test]
-        fn roundtrip_escape(payload in proptest::collection::vec(0..255u8, 5..20)) {
+        fn roundtrip_escape_async(payload in proptest::collection::vec(0..255u8, 5..20)) {
             start_log();
+            smol::block_on(do_roundtrip_async(&payload))
+        }
 
-            smol::block_on(do_roundtrip(&payload))
-
+        #[cfg(not(feature = "embassy"))]
+        #[test]
+        fn roundtrip_escape_sync(payload in proptest::collection::vec(0..255u8, 5..20)) {
+            start_log();
+            do_roundtrip_sync(&payload)
         }
     }
 }

--- a/mctp-estack/tests/roundtrip.rs
+++ b/mctp-estack/tests/roundtrip.rs
@@ -3,6 +3,11 @@
  * Copyright (c) 2025 Code Construct
  */
 
+// Roundtrip heavily relies on the router implementation that we currently have
+// to remove for a working synchronous implementaion.
+// For now, exclude the entire roundtrip test.
+#![cfg(feature = "embassy")]
+
 #[allow(unused)]
 use log::{debug, error, info, trace, warn};
 
@@ -10,6 +15,7 @@ use mctp::{Eid, MsgType};
 
 use mctp::{AsyncListener, AsyncReqChannel, AsyncRespChannel};
 use mctp_estack::config::NUM_RECEIVE;
+
 use mctp_estack::router::{
     Port, PortId, PortLookup, PortTop, RouterAsyncReqChannel,
 };


### PR DESCRIPTION
Adds sync support to `estack/serial`.

Rebased on branch [embassy-feature](https://github.com/9elements/mctp-rs/tree/embassy-feature)

Run the `sync` tests:
```
RUST_LOG=debug cargo test --features="" serial::tests::roundtrip_cases_sync -- --exact --nocapture
```

Run the `async` tests:
```
RUST_LOG=debug cargo test --features="embassy" serial::tests::roundtrip_cases_async -- --exact --nocapture
```